### PR TITLE
Add MDC WEB_BROWSER as input_source #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Data:
                       DISPLAY_PORT_3 | RF_TV | HDMI3 | HDMI3_PC | HDMI4 |
                       HDMI4_PC | TV_DTV | PLUG_IN_MODE | HD_BASE_T |
                       MEDIA_MAGIC_INFO_S | WIDI_SCREEN_MIRRORING |
-                      INTERNAL_USB | URL_LAUNCHER | IWB
+                      INTERNAL_USB | URL_LAUNCHER | IWB | WEB_BROWSER
 ```
 #### picture_aspect<a id="picture_aspect"></a>
 ```

--- a/samsung_mdc/commands.py
+++ b/samsung_mdc/commands.py
@@ -151,6 +151,7 @@ class INPUT_SOURCE(Command):
         INTERNAL_USB = 0x62
         URL_LAUNCHER = 0x63
         IWB = 0x64
+        WEB_BROWSER = 0x65
 
     DATA = [INPUT_SOURCE_STATE]
 


### PR DESCRIPTION
## Add MDC WEB_BROWSER as input_source 

Adding Web Browser as an `input_source`: `WEB_BROWSER`

See Issue #5 for details:

https://github.com/vgavro/samsung-mdc/issues/5
